### PR TITLE
support `wallet_sendTransaction`, throw error correctly when transaction fails, add 7702 transaction support

### DIFF
--- a/solidity/ts/testsuite/simulator/MockWindowEthereum.ts
+++ b/solidity/ts/testsuite/simulator/MockWindowEthereum.ts
@@ -122,6 +122,7 @@ export const getMockedEthSimulateWindowEthereum = (): MockWindowEthereum => {
 					const result = ethereumClientService.getChainId()
 					return EthereumQuantity.serialize(result)
 				}
+				case 'wallet_sendTransaction':
 				case 'eth_sendTransaction': {
 					//TODO, only one transaction should be included at once
 					const blockDelta = simulationState?.blocks.length || 0 // always create new block to add transactions to
@@ -129,6 +130,11 @@ export const getMockedEthSimulateWindowEthereum = (): MockWindowEthereum => {
 					if (transaction.success === false) throw new Error(transaction.error?.message)
 					const signed = mockSignTransaction(transaction.transaction)
 					simulationState = await appendTransaction(ethereumClientService, undefined, simulationState, [transaction.transaction], blockDelta)
+					const lastTx = simulationState.blocks.at(-1)?.simulatedTransactions.at(-1)
+					if (lastTx === undefined) throw new Error('Failed To append transaction')
+					if (lastTx.ethSimulateV1CallResult.status === 'failure') {
+						throw new ErrorWithDataAndCode(lastTx.ethSimulateV1CallResult.error.code, lastTx.ethSimulateV1CallResult.error.message, lastTx.ethSimulateV1CallResult.returnData)
+					}
 					return EthereumBytes32.serialize(signed.hash)
 				}
 				case 'eth_blockNumber': {

--- a/solidity/ts/testsuite/simulator/SimulationModeEthereumClientService.ts
+++ b/solidity/ts/testsuite/simulator/SimulationModeEthereumClientService.ts
@@ -1,5 +1,5 @@
 import { EthereumClientService } from './EthereumClientService.js'
-import { EthereumUnsignedTransaction, EthereumSignedTransactionWithBlockData, EthereumBlockTag, EthereumAddress, EthereumBlockHeader, EthereumBlockHeaderWithTransactionHashes, EthereumData, EthereumQuantity, EthereumBytes32, EthereumSendableSignedTransaction } from './types/wire-types.js'
+import { EthereumUnsignedTransaction, EthereumSignedTransactionWithBlockData, EthereumBlockTag, EthereumAddress, EthereumBlockHeader, EthereumBlockHeaderWithTransactionHashes, EthereumData, EthereumQuantity, EthereumBytes32, EthereumSendableSignedTransaction, EthereumBlockHeaderTransaction } from './types/wire-types.js'
 import { addressString, bigintToUint8Array, bytes32String, calculateWeightedPercentile, dataString, dataStringWith0xStart, max, min, stringToUint8Array } from './utils/bigint.js'
 import { CANNOT_SIMULATE_OFF_LEGACY_BLOCK, ERROR_INTERCEPTOR_GAS_ESTIMATION_FAILED, ETHEREUM_EIP1559_BASEFEECHANGEDENOMINATOR, ETHEREUM_EIP1559_ELASTICITY_MULTIPLIER, MOCK_ADDRESS, DEFAULT_CALL_ADDRESS, GAS_PER_BLOB } from './utils/constants.js'
 import { SimulatedTransaction, SimulationState, EstimateGasError, SimulationStateInput } from './types/visualizerTypes.js'
@@ -100,10 +100,16 @@ export const mockSignTransaction = (transaction: EthereumUnsignedTransaction) : 
 		if (transaction.type !== 'legacy') throw new Error('types do not match')
 		return { ...transaction, ...signatureParams, hash }
 	}
-
+	if (unsignedTransaction.type === '7702') {
+		const signatureParams = { r: 0n, s: 0n, yParity: 'even' as const }
+		const authorizationList = unsignedTransaction.authorizationList.map((element) => ({ ...element, ...signatureParams }))
+		const hash = EthereumQuantity.parse(keccak256(serializeSignedTransactionToBytes({ ...unsignedTransaction, ...signatureParams, authorizationList })))
+		if (transaction.type !== '7702') throw new Error('types do not match')
+		return { ...transaction, ...signatureParams, hash, authorizationList }
+	}
 	const signatureParams = { r: 0n, s: 0n, yParity: 'even' as const }
 	const hash = EthereumQuantity.parse(keccak256(serializeSignedTransactionToBytes({ ...unsignedTransaction, ...signatureParams })))
-	if (transaction.type === 'legacy') throw new Error('types do not match')
+	if (transaction.type === 'legacy' || transaction.type === '7702') throw new Error('types do not match')
 	return { ...transaction, ...signatureParams, hash }
 }
 
@@ -265,19 +271,32 @@ export const getSimulatedTransactionReceipt = async (ethereumClientService: Ethe
 	let cumGas = 0n
 	let currentLogIndex = 0
 	if (simulationState === undefined) { return await ethereumClientService.getTransactionReceipt(hash, requestAbortController) }
+
+	const getTransactionSpecificFields = (signedTransaction: EthereumSendableSignedTransaction) => {
+		switch(signedTransaction.type) {
+			case 'legacy':
+			case '1559':
+			case '2930': return { type: signedTransaction.type }
+			case '4844': return {
+				type: signedTransaction.type,
+				blobGasUsed: GAS_PER_BLOB * BigInt(signedTransaction.blobVersionedHashes.length),
+				blobGasPrice: signedTransaction.maxFeePerBlobGas,
+			}
+			case '7702': return {
+				type: signedTransaction.type,
+				authorizationList: signedTransaction.authorizationList
+			}
+			default: assertNever(signedTransaction)
+		}
+	}
+
 	const blockNum = await ethereumClientService.getBlockNumber(requestAbortController)
 	for (const [blockDelta, block] of simulationState.blocks.entries()) {
 		for (const [transactionIndex, simulatedTransaction] of block.simulatedTransactions.entries()) {
 			cumGas += simulatedTransaction.ethSimulateV1CallResult.gasUsed
 			if (hash === simulatedTransaction.preSimulationTransaction.hash) {
 				return {
-					...simulatedTransaction.preSimulationTransaction.type === '4844' ? {
-						type: simulatedTransaction.preSimulationTransaction.type,
-						blobGasUsed: GAS_PER_BLOB * BigInt(simulatedTransaction.preSimulationTransaction.blobVersionedHashes.length),
-						blobGasPrice: simulatedTransaction.preSimulationTransaction.maxFeePerBlobGas,
-					} : {
-						type: simulatedTransaction.preSimulationTransaction.type,
-					},
+					...getTransactionSpecificFields(simulatedTransaction.preSimulationTransaction),
 					blockHash: getHashOfSimulatedBlock(simulationState, blockDelta),
 					blockNumber: blockNum + BigInt(blockDelta) + 1n,
 					transactionHash: simulatedTransaction.preSimulationTransaction.hash,
@@ -692,9 +711,13 @@ export const getSimulatedFeeHistory = async (ethereumClientService: EthereumClie
 		...rewardPercentiles === undefined ? {} : {
 			reward: [rewardPercentiles.map((percentile) => {
 				// we are using transaction.gas as a weighting factor while this should be `gasUsed`. Getting `gasUsed` requires getting transaction receipts, which we don't want to be doing
-				const effectivePriorityAndGasWeights = newestBlock.transactions.map((tx) => tx.type === '1559' || tx.type === '4844' ?
-					{ dataPoint: min(tx.maxPriorityFeePerGas, tx.maxFeePerGas - (newestBlockBaseFeePerGas ?? 0n)), weight: tx.gas }
-					: { dataPoint: tx.gasPrice - (newestBlockBaseFeePerGas ?? 0n), weight: tx.gas })
+				const getDataPoint = (tx: EthereumBlockHeaderTransaction) => {
+					if ('maxPriorityFeePerGas' in tx && 'maxFeePerGas' in tx && 'gas' in tx) return { dataPoint: min(tx.maxPriorityFeePerGas, tx.maxFeePerGas - (newestBlockBaseFeePerGas ?? 0n)), weight: tx.gas }
+					if ('gasPrice' in tx && 'gas' in tx) return { dataPoint: tx.gasPrice - (newestBlockBaseFeePerGas ?? 0n), weight: tx.gas }
+					return { dataPoint: 0n, weight: 0n }
+				}
+
+				const effectivePriorityAndGasWeights = newestBlock.transactions.map((tx) => getDataPoint(tx))
 
 				// we can have negative values here, as The Interceptor creates maxFeePerGas = 0 transactions that are intended to have zero base fee, which is not possible in reality
 				const zeroOutNegativeValues = effectivePriorityAndGasWeights.map((point) => modifyObject(point, { dataPoint: max(0n, point.dataPoint) }))

--- a/solidity/ts/testsuite/simulator/types/ethSimulateTypes.ts
+++ b/solidity/ts/testsuite/simulator/types/ethSimulateTypes.ts
@@ -11,8 +11,8 @@ const AccountOverride = funtypes.ReadonlyPartial({
 	movePrecompileToAddress: EthereumAddress,
 })
 
-type BlockOverrides = funtypes.Static<typeof BlockOverrides>
-const BlockOverrides = funtypes.Partial({
+export type BlockOverrides = funtypes.Static<typeof BlockOverrides>
+export const BlockOverrides = funtypes.Partial({
     number: EthereumQuantity,
     prevRandao: EthereumBytes32,
     time: EthereumTimestamp,
@@ -21,14 +21,15 @@ const BlockOverrides = funtypes.Partial({
     baseFeePerGas: EthereumQuantity,
 }).asReadonly()
 
-export type BlockCall = funtypes.Static<typeof BlockCall>
-export const BlockCall = funtypes.Partial({
+type BlockCall = funtypes.Static<typeof BlockCall>
+const BlockCall = funtypes.Partial({
 	type: funtypes.Union(
 		funtypes.Literal('0x0').withParser(LiteralConverterParserFactory('0x0', 'legacy' as const)),
 		funtypes.Literal(undefined).withParser(LiteralConverterParserFactory(undefined, 'legacy' as const)),
 		funtypes.Literal('0x1').withParser(LiteralConverterParserFactory('0x1', '2930' as const)),
 		funtypes.Literal('0x2').withParser(LiteralConverterParserFactory('0x2', '1559' as const)),
 		funtypes.Literal('0x3').withParser(LiteralConverterParserFactory('0x3', '4844' as const)),
+		funtypes.Literal('0x4').withParser(LiteralConverterParserFactory('0x4', '7702' as const)),
 	),
 	from: EthereumAddress,
 	nonce: EthereumQuantity,
@@ -40,10 +41,18 @@ export const BlockCall = funtypes.Partial({
 	input: EthereumInput,
 	chainId: EthereumQuantity,
 	accessList: EthereumAccessList,
+	authorizationList: funtypes.ReadonlyArray(funtypes.ReadonlyObject({
+		chainId: EthereumQuantity,
+		address: EthereumAddress,
+		nonce: EthereumQuantity,
+	}))
 })
 
 export type StateOverrides = funtypes.Static<typeof StateOverrides>
 export const StateOverrides = funtypes.ReadonlyRecord(funtypes.String, AccountOverride)
+
+export type MutableStateOverrides = funtypes.Static<typeof MutableStateOverrides>
+export const MutableStateOverrides = funtypes.Record(funtypes.String, AccountOverride)
 
 export type BlockCalls = funtypes.Static<typeof BlockCalls>
 export const BlockCalls = funtypes.Intersect(
@@ -56,7 +65,7 @@ export const BlockCalls = funtypes.Intersect(
 	})
 )
 
-export type EthSimulateV1ParamObject = funtypes.Static<typeof EthSimulateV1ParamObject>
+type EthSimulateV1ParamObject = funtypes.Static<typeof EthSimulateV1ParamObject>
 const EthSimulateV1ParamObject = funtypes.ReadonlyObject({
 	blockStateCalls: funtypes.ReadonlyArray(BlockCalls),
 	traceTransfers: funtypes.Boolean,
@@ -81,7 +90,7 @@ const CallResultLog = funtypes.Intersect(
 	EthereumEvent,
 	funtypes.ReadonlyObject({
 		logIndex: EthereumQuantity,
-		blockHash: EthereumBytes32,
+		blockHash: funtypes.Union(EthereumBytes32, funtypes.Null), // Base returns null for this at times
 		blockNumber: EthereumQuantity,
 	}),
 	funtypes.ReadonlyPartial({ // these are not optional in the eth_simulateV1 spec, but they are not standard for logs
@@ -100,7 +109,7 @@ const EthSimulateCallResultFailure = funtypes.ReadonlyObject({
 	  gasUsed: EthereumQuantitySmall,
 	  error: funtypes.ReadonlyObject({
 		  code: funtypes.Number,
-		  message: funtypes.String,
+		  message: funtypes.String
 	  })
 })
 

--- a/solidity/ts/testsuite/simulator/types/ethereum.ts
+++ b/solidity/ts/testsuite/simulator/types/ethereum.ts
@@ -80,6 +80,53 @@ interface IUnsignedTransaction4844 {
 	readonly blobVersionedHashes: readonly bigint[]
 }
 
+export interface IUnsignedTransaction7702 {
+	readonly type: '7702'
+	readonly from: bigint
+	readonly chainId: bigint
+	readonly nonce: bigint
+	readonly maxFeePerGas: bigint
+	readonly maxPriorityFeePerGas: bigint
+	readonly gasLimit: bigint
+	readonly to: bigint | null
+	readonly value: bigint
+	readonly input: Uint8Array
+	readonly accessList: readonly {
+		readonly address: bigint
+		readonly storageKeys: readonly bigint[]
+	}[]
+	readonly authorizationList: readonly {
+		chainId: bigint
+		address: bigint
+		nonce: bigint
+	}[]
+}
+
+type ISignedTransaction7702 = {
+	readonly type: '7702'
+	readonly from: bigint
+	readonly chainId: bigint
+	readonly nonce: bigint
+	readonly maxFeePerGas: bigint
+	readonly maxPriorityFeePerGas: bigint
+	readonly gasLimit: bigint
+	readonly to: bigint | null
+	readonly value: bigint
+	readonly input: Uint8Array
+	readonly accessList: readonly {
+		readonly address: bigint
+		readonly storageKeys: readonly bigint[]
+	}[]
+	readonly authorizationList: readonly {
+		chainId: bigint,
+		address: bigint,
+		nonce: bigint,
+		yParity: 'even' | 'odd',
+		r: bigint,
+		s: bigint
+	}[]
+} & ITransactionSignature1559and2930and4844
+
 type ITransactionSignatureLegacy = {
 	readonly r: bigint
 	readonly s: bigint
@@ -98,12 +145,12 @@ type ITransactionSignature1559and2930and4844 = {
 	readonly hash: bigint
 }
 
-type IUnsignedTransaction = IUnsignedTransactionLegacy | IUnsignedTransaction2930 | IUnsignedTransaction1559 | IUnsignedTransaction4844
+type IUnsignedTransaction = IUnsignedTransactionLegacy | IUnsignedTransaction2930 | IUnsignedTransaction1559 | IUnsignedTransaction4844 | IUnsignedTransaction7702
 type ISignedTransaction1559 = IUnsignedTransaction1559 & ITransactionSignature1559and2930and4844
 type ISignedTransactionLegacy = IUnsignedTransactionLegacy & ITransactionSignatureLegacy
 type ISignedTransaction2930 = IUnsignedTransaction2930 & ITransactionSignature1559and2930and4844
 type ISignedTransaction4844 = IUnsignedTransaction4844 & ITransactionSignature1559and2930and4844
-type ISignedTransaction = ISignedTransaction1559 | ISignedTransactionLegacy | ISignedTransaction2930 | ISignedTransaction4844 | IOptimismDepositTransaction
+type ISignedTransaction = ISignedTransaction1559 | ISignedTransactionLegacy | ISignedTransaction2930 | ISignedTransaction4844 | IOptimismDepositTransaction | ISignedTransaction7702
 
 function calculateV(transaction: DistributiveOmit<ITransactionSignatureLegacy, 'hash'>): bigint {
 	if ('v' in transaction) return transaction.v
@@ -156,6 +203,30 @@ function rlpEncodeSigned1559TransactionPayload(transaction: DistributiveOmit<ISi
 		stripLeadingZeros(bigintToUint8Array(transaction.value, 32)),
 		transaction.input,
 		transaction.accessList.map(({address, storageKeys}) => [bigintToUint8Array(address, 20), storageKeys.map(slot => bigintToUint8Array(slot, 32))]),
+		stripLeadingZeros(new Uint8Array([transaction.yParity === 'even' ? 0 : 1])),
+		stripLeadingZeros(bigintToUint8Array(transaction.r, 32)),
+		stripLeadingZeros(bigintToUint8Array(transaction.s, 32)),
+	])
+}
+function rlpEncodeSigned7702TransactionPayload(transaction: DistributiveOmit<ISignedTransaction7702, 'hash'>): Uint8Array {
+	return rlpEncode([
+		stripLeadingZeros(bigintToUint8Array(transaction.chainId, 32)),
+		stripLeadingZeros(bigintToUint8Array(transaction.nonce, 32)),
+		stripLeadingZeros(bigintToUint8Array(transaction.maxPriorityFeePerGas, 32)),
+		stripLeadingZeros(bigintToUint8Array(transaction.maxFeePerGas, 32)),
+		stripLeadingZeros(bigintToUint8Array(transaction.gasLimit, 32)),
+		transaction.to !== null ? bigintToUint8Array(transaction.to, 20) : new Uint8Array(0),
+		stripLeadingZeros(bigintToUint8Array(transaction.value, 32)),
+		transaction.input,
+		transaction.accessList.map(({address, storageKeys}) => [bigintToUint8Array(address, 20), storageKeys.map(slot => bigintToUint8Array(slot, 32))]),
+		transaction.authorizationList.map(({ chainId, address, nonce, yParity, r, s }) => [
+			stripLeadingZeros(bigintToUint8Array(chainId, 32)),
+			bigintToUint8Array(address, 20),
+			stripLeadingZeros(bigintToUint8Array(nonce, 32)),
+			stripLeadingZeros(new Uint8Array([yParity === 'even' ? 0 : 1])),
+			stripLeadingZeros(bigintToUint8Array(r, 32)),
+			stripLeadingZeros(bigintToUint8Array(s, 32)),
+		]),
 		stripLeadingZeros(new Uint8Array([transaction.yParity === 'even' ? 0 : 1])),
 		stripLeadingZeros(bigintToUint8Array(transaction.r, 32)),
 		stripLeadingZeros(bigintToUint8Array(transaction.s, 32)),
@@ -221,7 +292,7 @@ function rlpEncodeUnsigned1559TransactionPayload(transaction: IUnsignedTransacti
 		transaction.to !== null ? bigintToUint8Array(transaction.to, 20) : new Uint8Array(0),
 		stripLeadingZeros(bigintToUint8Array(transaction.value, 32)),
 		transaction.input,
-		transaction.accessList.map(({address, storageKeys}) => [bigintToUint8Array(address, 20), storageKeys.map(slot => bigintToUint8Array(slot, 32))]),
+		transaction.accessList.map(({ address, storageKeys }) => [bigintToUint8Array(address, 20), storageKeys.map(slot => bigintToUint8Array(slot, 32))]),
 	]
 	return rlpEncode(toEncode)
 }
@@ -243,11 +314,32 @@ function rlpEncodeUnsigned4844TransactionPayload(transaction: IUnsignedTransacti
 	return rlpEncode(toEncode)
 }
 
+function rlpEncodeUnsigned7702TransactionPayload(transaction: IUnsignedTransaction7702): Uint8Array {
+	const toEncode = [
+		stripLeadingZeros(bigintToUint8Array(transaction.chainId, 32)),
+		stripLeadingZeros(bigintToUint8Array(transaction.nonce, 32)),
+		stripLeadingZeros(bigintToUint8Array(transaction.maxPriorityFeePerGas, 32)),
+		stripLeadingZeros(bigintToUint8Array(transaction.maxFeePerGas, 32)),
+		stripLeadingZeros(bigintToUint8Array(transaction.gasLimit, 32)),
+		transaction.to !== null ? bigintToUint8Array(transaction.to, 20) : new Uint8Array(0),
+		stripLeadingZeros(bigintToUint8Array(transaction.value, 32)),
+		transaction.input,
+		transaction.accessList.map(({ address, storageKeys }) => [bigintToUint8Array(address, 20), storageKeys.map(slot => bigintToUint8Array(slot, 32))]),
+		transaction.authorizationList.map(({ chainId, address, nonce }) => [
+			stripLeadingZeros(bigintToUint8Array(chainId, 32)),
+			bigintToUint8Array(address, 20),
+			stripLeadingZeros(bigintToUint8Array(nonce, 32)),
+		]),
+	]
+	return rlpEncode(toEncode)
+}
+
 export function serializeSignedTransactionToBytes(transaction: DistributiveOmit<ISignedTransaction, 'hash'>): Uint8Array {
 	switch (transaction.type) {
 		case 'legacy': return rlpEncodeSignedLegacyTransactionPayload(transaction)
 		case '2930': return new Uint8Array([1, ...rlpEncodeSigned2930TransactionPayload(transaction)])
 		case '1559': return new Uint8Array([2, ...rlpEncodeSigned1559TransactionPayload(transaction)])
+		case '7702': return new Uint8Array([2, ...rlpEncodeSigned7702TransactionPayload(transaction)])
 		case '4844': return new Uint8Array([2, ...rlpEncodeSigned4844TransactionPayload(transaction)])
 		case 'optimismDeposit': throw new Error('Serializing optimismDeposit (0x7e) transaction is not supported')
 		default: assertNever(transaction)
@@ -259,6 +351,7 @@ export function serializeUnsignedTransactionToBytes(transaction: IUnsignedTransa
 		case 'legacy': return rlpEncodeUnsignedLegacyTransactionPayload(transaction)
 		case '2930': return new Uint8Array([1, ...rlpEncodeUnsigned2930TransactionPayload(transaction)])
 		case '1559': return new Uint8Array([2, ...rlpEncodeUnsigned1559TransactionPayload(transaction)])
+		case '7702': return new Uint8Array([2, ...rlpEncodeUnsigned7702TransactionPayload(transaction)])
 		case '4844': return new Uint8Array([1, ...rlpEncodeUnsigned4844TransactionPayload(transaction)])
 		default: assertNever(transaction)
 	}
@@ -266,6 +359,7 @@ export function serializeUnsignedTransactionToBytes(transaction: IUnsignedTransa
 
 export function EthereumUnsignedTransactionToUnsignedTransaction(transaction: EthereumUnsignedTransaction): IUnsignedTransaction {
 	switch (transaction.type) {
+		case '7702':
 		case '4844':
 		case '2930':
 		case '1559': {
@@ -290,6 +384,7 @@ export function EthereumSignedTransactionToSignedTransaction(transaction: Ethere
 	switch (transaction.type) {
 		case '4844':
 		case '2930':
+		case '7702':
 		case '1559': return {
 			...transaction,
 			yParity: 'yParity' in transaction ? transaction.yParity : (transaction.v === 0n ? 'even' : 'odd'),

--- a/solidity/ts/testsuite/simulator/types/wire-types.ts
+++ b/solidity/ts/testsuite/simulator/types/wire-types.ts
@@ -1,5 +1,6 @@
 import * as funtypes from 'funtypes'
 import { UnionToIntersection } from '../utils/typescript.js'
+import { isHexEncodedNumber } from '../utils/bigint.js'
 
 const BigIntParser: funtypes.ParsedValue<funtypes.String, bigint>['config'] = {
 	parse: value => {
@@ -233,6 +234,30 @@ const EthereumUnsignedTransaction1559 = funtypes.Intersect(
 	}).asReadonly(),
 )
 
+type EthereumUnsignedTransaction7702 = funtypes.Static<typeof EthereumUnsignedTransaction7702>
+const EthereumUnsignedTransaction7702 = funtypes.Intersect(
+	funtypes.ReadonlyObject({
+		type: funtypes.Literal('0x4').withParser(LiteralConverterParserFactory('0x4', '7702' as const)),
+		from: EthereumAddress,
+		nonce: EthereumQuantity,
+		maxFeePerGas: EthereumQuantity,
+		maxPriorityFeePerGas: EthereumQuantity,
+		gas: EthereumQuantity,
+		to: funtypes.Union(EthereumAddress, funtypes.Null),
+		value: EthereumQuantity,
+		input: EthereumInput,
+		chainId: EthereumQuantity,
+		authorizationList: funtypes.ReadonlyArray(funtypes.ReadonlyObject({
+			chainId: EthereumQuantity,
+			address: EthereumAddress,
+			nonce: EthereumQuantity,
+		}))
+	}).asReadonly(),
+	funtypes.Partial({
+		accessList: EthereumAccessList,
+	}).asReadonly(),
+)
+
 type EthereumUnsignedTransaction4844  = funtypes.Static<typeof EthereumUnsignedTransaction4844>
 const EthereumUnsignedTransaction4844 = funtypes.Intersect(
 	funtypes.ReadonlyObject({
@@ -255,7 +280,7 @@ const EthereumUnsignedTransaction4844 = funtypes.Intersect(
 )
 
 export type EthereumUnsignedTransaction = funtypes.Static<typeof EthereumUnsignedTransaction>
-export const EthereumUnsignedTransaction = funtypes.Union(EthereumUnsignedTransactionLegacy, EthereumUnsignedTransaction2930, EthereumUnsignedTransaction1559, EthereumUnsignedTransaction4844)
+export const EthereumUnsignedTransaction = funtypes.Union(EthereumUnsignedTransactionLegacy, EthereumUnsignedTransaction2930, EthereumUnsignedTransaction1559, EthereumUnsignedTransaction4844, EthereumUnsignedTransaction7702)
 
 type OptionalEthereumUnsignedTransaction1559 = funtypes.Static<typeof EthereumUnsignedTransaction1559>
 const OptionalEthereumUnsignedTransaction1559 = funtypes.Intersect(
@@ -297,8 +322,32 @@ const OptionalEthereumUnsignedTransaction4844 = funtypes.Intersect(
 	}).asReadonly(),
 )
 
+type OptionalEthereumUnsignedTransaction7702 = funtypes.Static<typeof EthereumUnsignedTransaction7702>
+const OptionalEthereumUnsignedTransaction7702 = funtypes.Intersect(
+	funtypes.ReadonlyObject({
+		type: funtypes.Literal('0x4').withParser(LiteralConverterParserFactory('0x4', '7702' as const)),
+		from: EthereumAddress,
+		nonce: EthereumQuantity,
+		to: funtypes.Union(EthereumAddress, funtypes.Null),
+		value: EthereumQuantity,
+		input: EthereumInput,
+		chainId: EthereumQuantity,
+		authorizationList: funtypes.ReadonlyArray(funtypes.ReadonlyObject({
+			chainId: EthereumQuantity,
+			address: EthereumAddress,
+			nonce: EthereumQuantity,
+		}))
+	}).asReadonly(),
+	funtypes.Partial({
+		gas: EthereumQuantity,
+		maxFeePerGas: EthereumQuantity,
+		maxPriorityFeePerGas: EthereumQuantity,
+		accessList: EthereumAccessList,
+	}).asReadonly(),
+)
+
 export type OptionalEthereumUnsignedTransaction = funtypes.Static<typeof OptionalEthereumUnsignedTransaction>
-export const OptionalEthereumUnsignedTransaction = funtypes.Union(EthereumUnsignedTransactionLegacy, EthereumUnsignedTransaction2930, OptionalEthereumUnsignedTransaction1559, OptionalEthereumUnsignedTransaction4844)
+export const OptionalEthereumUnsignedTransaction = funtypes.Union(EthereumUnsignedTransactionLegacy, EthereumUnsignedTransaction2930, OptionalEthereumUnsignedTransaction1559, OptionalEthereumUnsignedTransaction4844, OptionalEthereumUnsignedTransaction7702)
 
 const EthereumTransaction2930And1559And4844Signature = funtypes.Intersect(
 	funtypes.ReadonlyObject({
@@ -361,6 +410,34 @@ const EthereumSignedTransaction2930 = funtypes.Intersect(
 	EthereumTransaction2930And1559And4844Signature,
 )
 
+type EthereumSignedTransaction7702 = funtypes.Static<typeof EthereumSignedTransaction7702>
+const EthereumSignedTransaction7702 = funtypes.Intersect(
+	funtypes.ReadonlyObject({
+		type: funtypes.Literal('0x4').withParser(LiteralConverterParserFactory('0x4', '7702' as const)),
+		from: EthereumAddress,
+		nonce: EthereumQuantity,
+		maxFeePerGas: EthereumQuantity,
+		maxPriorityFeePerGas: EthereumQuantity,
+		gas: EthereumQuantity,
+		to: funtypes.Union(EthereumAddress, funtypes.Null),
+		value: EthereumQuantity,
+		input: EthereumInput,
+		chainId: EthereumQuantity,
+		authorizationList: funtypes.ReadonlyArray(funtypes.ReadonlyObject({
+			chainId: EthereumQuantity,
+			address: EthereumAddress,
+			nonce: EthereumQuantity,
+			r: EthereumQuantity,
+			s: EthereumQuantity,
+			yParity: funtypes.Union(funtypes.Literal('0x0').withParser(LiteralConverterParserFactory('0x0', 'even' as const)), funtypes.Literal('0x1').withParser(LiteralConverterParserFactory('0x1', 'odd' as const)))
+		}))
+	}).asReadonly(),
+	funtypes.Partial({
+		accessList: EthereumAccessList,
+	}).asReadonly(),
+	EthereumTransaction2930And1559And4844Signature
+)
+
 export type EthereumSignedTransaction1559 = funtypes.Static<typeof EthereumSignedTransaction1559>
 export const EthereumSignedTransaction1559 = funtypes.Intersect(
 	EthereumUnsignedTransaction1559,
@@ -374,7 +451,7 @@ const EthereumSignedTransaction4844 = funtypes.Intersect(
 )
 
 export type EthereumSendableSignedTransaction = funtypes.Static<typeof EthereumSendableSignedTransaction>
-export const EthereumSendableSignedTransaction = funtypes.Union(EthereumSignedTransactionLegacy, EthereumSignedTransaction2930, EthereumSignedTransaction1559, EthereumSignedTransaction4844)
+export const EthereumSendableSignedTransaction = funtypes.Union(EthereumSignedTransactionLegacy, EthereumSignedTransaction2930, EthereumSignedTransaction1559, EthereumSignedTransaction4844, EthereumSignedTransaction7702)
 
 export type EthereumSignedTransaction = funtypes.Static<typeof EthereumSignedTransaction>
 export const EthereumSignedTransaction = funtypes.Union(EthereumSendableSignedTransaction, EthereumSignedTransactionOptimismDeposit)
@@ -386,6 +463,7 @@ export const EthereumSignedTransactionWithBlockData = funtypes.Intersect(
 		EthereumSignedTransaction2930,
 		funtypes.Intersect(EthereumSignedTransaction1559, funtypes.ReadonlyObject({ gasPrice: EthereumQuantity })),
 		funtypes.Intersect(EthereumSignedTransaction4844, funtypes.ReadonlyObject({ gasPrice: EthereumQuantity })),
+		funtypes.Intersect(EthereumSignedTransaction7702, funtypes.ReadonlyObject({ gasPrice: EthereumQuantity })),
 	),
 	funtypes.ReadonlyObject({
 		data: EthereumInput,
@@ -448,10 +526,24 @@ export const EthereumBlockHeaderWithTransactionHashes = funtypes.Union(funtypes.
 	funtypes.ReadonlyObject({ transactions: funtypes.ReadonlyArray(EthereumBytes32) })
 ))
 
+type EthereumUnknownTransactionType = funtypes.Static<typeof EthereumUnknownTransactionType>
+const EthereumUnknownTransactionType = funtypes.ReadonlyObject({
+	hash: EthereumBytes32,
+	type: funtypes.String.withConstraint((type) => {
+		if (!isHexEncodedNumber(type)) return false
+		const alreadyHandled = ['0x0', '0x1', '0x2', '0x3', '0x4', '0x7e']
+		if (alreadyHandled.includes(type)) return false
+		return true
+	})
+})
+
+export type EthereumBlockHeaderTransaction = funtypes.Static<typeof EthereumBlockHeaderTransaction>
+export const EthereumBlockHeaderTransaction = funtypes.Union(EthereumSignedTransaction, EthereumUnknownTransactionType)
+
 export type EthereumBlockHeader = funtypes.Static<typeof EthereumBlockHeader>
 export const EthereumBlockHeader = funtypes.Union(funtypes.Null, funtypes.Intersect(
 	EthereumBlockHeaderWithoutTransactions,
-	funtypes.ReadonlyObject({ transactions: funtypes.ReadonlyArray(EthereumSignedTransaction) })
+	funtypes.ReadonlyObject({ transactions: funtypes.ReadonlyArray(EthereumBlockHeaderTransaction) })
 ))
 
 //


### PR DESCRIPTION
- Add support for `wallet_sendTransaction` method
- Throw error correctly when sent transaction fails (its still sent and included in a block, but we also throw error)
- Add support for 7702 transactions